### PR TITLE
Prom stuff

### DIFF
--- a/provision-databases.yml
+++ b/provision-databases.yml
@@ -49,3 +49,6 @@
   hosts: databases
   roles:
     - prometheus-server
+  vars_files:
+    - vars/traefik.yml
+    - vars/secrets.yml

--- a/roles/prometheus-server/defaults/main.yml
+++ b/roles/prometheus-server/defaults/main.yml
@@ -1,0 +1,2 @@
+prometheus_parent_dir: "/mnt/data-disk/"
+blackbox_exporter_parent_dir: "/mnt/data-disk/"

--- a/roles/prometheus-server/files/blackbox_exporter.yaml
+++ b/roles/prometheus-server/files/blackbox_exporter.yaml
@@ -1,3 +1,9 @@
 modules:
   http_2xx:
     prober: http
+  http_2xx_traefik_auth:
+    prober: http
+    http:
+      basic_auth:
+        username: "{{ traefik.username }}"
+        password: "{{ traefik.password }}"

--- a/roles/prometheus-server/tasks/main.yml
+++ b/roles/prometheus-server/tasks/main.yml
@@ -48,7 +48,8 @@
 
 - name: "Copy Blackbox Config"
   become: yes
-  copy:
+  template:
+    mode: 0440
     src: "files/blackbox_exporter.yaml"
     dest: "/mnt/data-disk/blackbox_exporter/blackbox_exporter.yaml"
   notify:
@@ -78,6 +79,7 @@
     ports:
       - "9090:9090"
     restart_policy: on-failure
+    restart_retries: 3
     volumes:
       - "/mnt/data-disk/prometheus/config:/etc/prometheus"
       - "/mnt/data-disk/prometheus/data:/prometheus"
@@ -93,5 +95,6 @@
     image: "prom/blackbox-exporter:v0.17.0"
     command: "--config.file=/config/blackbox_exporter.yaml"
     restart_policy: on-failure
+    restart_retries: 3
     volumes:
     - "/mnt/data-disk/blackbox_exporter/blackbox_exporter.yaml:/config/blackbox_exporter.yaml"

--- a/roles/prometheus-server/tasks/main.yml
+++ b/roles/prometheus-server/tasks/main.yml
@@ -1,35 +1,35 @@
 ---
-- name: "Create /mnt/data-disk/prometheus directory"
+- name: "Create prometheus directory"
   become: yes
   file:
-    path: /mnt/data-disk/prometheus
+    path: "{{ prometheus_parent_dir }}/prometheus"
     mode: 0770 
     owner: nobody # Prometheus runs as nobody
     group: nogroup
     state: directory
 
-- name: "Create /mnt/data-disk/prometheus/config directory"
+- name: "Create prometheus/config directory"
   become: yes
   file:
-    path: /mnt/data-disk/prometheus/config
+    path: "{{ prometheus_parent_dir }}/prometheus/config"
     mode: 0770 
     owner: nobody
     group: nogroup
     state: directory
 
-- name: "Create /mnt/data-disk/prometheus/data directory"
+- name: "Create prometheus/data directory"
   become: yes
   file:
-    path: /mnt/data-disk/prometheus/data
+    path: "{{ prometheus_parent_dir }}/prometheus/data"
     mode: 0770 
     owner: nobody
     group: nogroup
     state: directory
 
-- name: "Create /mnt/data-disk/blackbox_exporter directory"
+- name: "Create blackbox_exporter directory"
   become: yes
   file:
-    path: /mnt/data-disk/blackbox_exporter
+    path: "{{ blackbox_exporter_parent_dir }}/blackbox_exporter"
     mode: 0770 
     owner: root
     group: root
@@ -42,16 +42,16 @@
     owner: nobody
     group: nogroup
     src: "templates/prometheus.yml.j2"
-    dest: "/mnt/data-disk/prometheus/config/prometheus.yml"
+    dest: "{{ prometheus_parent_dir }}/prometheus/config/prometheus.yml"
   notify:
     - restart prometheus
 
-- name: "Copy Blackbox Config"
+- name: "Generate Blackbox Config"
   become: yes
   template:
     mode: 0440
     src: "files/blackbox_exporter.yaml"
-    dest: "/mnt/data-disk/blackbox_exporter/blackbox_exporter.yaml"
+    dest: "{{ blackbox_exporter_parent_dir }}/blackbox_exporter/blackbox_exporter.yaml"
   notify:
     - restart blackbox exporter
 
@@ -81,8 +81,8 @@
     restart_policy: on-failure
     restart_retries: 3
     volumes:
-      - "/mnt/data-disk/prometheus/config:/etc/prometheus"
-      - "/mnt/data-disk/prometheus/data:/prometheus"
+      - "{{ prometheus_parent_dir }}/prometheus/config:/etc/prometheus"
+      - "{{ prometheus_parent_dir }}/prometheus/data:/prometheus"
 
 - name: "Blackbox Exporter"
   become: yes
@@ -97,4 +97,4 @@
     restart_policy: on-failure
     restart_retries: 3
     volumes:
-    - "/mnt/data-disk/blackbox_exporter/blackbox_exporter.yaml:/config/blackbox_exporter.yaml"
+    - "{{ blackbox_exporter_parent_dir }}/blackbox_exporter/blackbox_exporter.yaml:/config/blackbox_exporter.yaml"

--- a/roles/prometheus-server/templates/prometheus.yml.j2
+++ b/roles/prometheus-server/templates/prometheus.yml.j2
@@ -117,8 +117,6 @@ scrape_configs:
 
   - job_name: 'site-up'
     metrics_path: /probe
-    params:
-      module: [http_2xx]
     static_configs:
       - targets:
         - 'https://netsoc.co/'
@@ -126,13 +124,20 @@ scrape_configs:
         - 'https://netsoc.dev/'
         - 'https://keycloak.netsoc.dev/'
         - 'https://portainer.netsoc.dev/'
-        - 'https://traefik.netsoc.dev/'
         - 'https://ipa.netsoc.dev/ipa/ui/'
         - 'https://uccexpress.ie/'
         - 'https://motley.ie/'
+        labels:
+          module: http_2xx
+      - targets:
+        - 'https://traefik.netsoc.dev/'
+        labels:
+          module: http_2xx_traefik_auth
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
+      - source_labels: [module]
+        target_label: __param_module
       - source_labels: [__param_target]
         target_label: instance
         regex: '^https?:\/\/(.*)\/'


### PR DESCRIPTION
Made paths variable (with defaults) for Prometheus Data & Config and Blackbox Exporter config


Blackbox exporter for traefik.netsoc.dev has basic auth. Alternatively we could forgo basic auth and check for a 401 unauthorized but I think checking for a 2xx is preferable