### PR TITLE
Traefik metrics

### DIFF
--- a/create-docker-swarm.yml
+++ b/create-docker-swarm.yml
@@ -17,6 +17,7 @@
               - docker_swarm_managers
               - prometheus_base
               - prometheus_docker
+              - prometheus_traefik
               - ipaclients
             host_vars:
               ansible_ssh_private_key_file: "./keys/docker_swarm/id_rsa"

--- a/provision-docker-swarm-services.yml
+++ b/provision-docker-swarm-services.yml
@@ -123,6 +123,11 @@
               address: ':80'
             web-secure:
               address: ':443'
+            metrics:
+              address: ':8082'
+          metrics:
+            prometheus:
+              entrypoint: metrics
           serversTransport:
             insecureSkipVerify: true
           certificatesResolvers:

--- a/roles/prometheus-exporter/templates/exporter_exporter.yaml.j2
+++ b/roles/prometheus-exporter/templates/exporter_exporter.yaml.j2
@@ -43,7 +43,7 @@ modules:
 
 {% endif %}
 
-{% if inventory_hostname is match("manager\\d+.vm.netsoc.co") %}
+{% if 'prometheus_traefik' in group_names %}
   traefik:
     method: http
     http:

--- a/roles/prometheus-exporter/templates/exporter_exporter.yaml.j2
+++ b/roles/prometheus-exporter/templates/exporter_exporter.yaml.j2
@@ -43,4 +43,11 @@ modules:
 
 {% endif %}
 
+{% if inventory_hostname is match("manager\\d+.vm.netsoc.co") %}
+  traefik:
+    method: http
+    http:
+      port: 8082
+{% endif %}
+
 

--- a/roles/prometheus-server/templates/prometheus.yml.j2
+++ b/roles/prometheus-server/templates/prometheus.yml.j2
@@ -115,6 +115,22 @@ scrape_configs:
 #        labels:
 #          instance: "games.vm.netsoc.co"
 
+{% if 'prometheus_traefik' in groups %}
+  - job_name: 'traefik'
+    metrics_path: /proxy
+    params:
+      module:
+       - traefik 
+    static_configs:
+    {% for host in groups['prometheus_traefik'] -%}
+      - 
+        targets:
+          - {{host}}:9999
+        labels:
+          instance: "{{host}}"
+    {% endfor %}
+{% endif %}
+
   - job_name: 'site-up'
     metrics_path: /probe
     static_configs:

--- a/roles/traefik-proxmox/tasks/main.yml
+++ b/roles/traefik-proxmox/tasks/main.yml
@@ -72,6 +72,10 @@
                 published: 443
                 protocol: tcp
                 mode: host
+              - target: 8082
+                published: 8082
+                protocol: tcp
+                mode: host
             networks:
               traefik:
             deploy:


### PR DESCRIPTION
Enabled Traefik Metrics; Port: 8082; Endpoint: /metrics

Added swarm managers to `prometheus_traefik` group

Reverse proxied metrics using exporter exporter

Added `prometheus_traefik` group to Prometheus scrape configs