### PR TITLE
Wetty

### DIFF
--- a/portal-banner.txt
+++ b/portal-banner.txt
@@ -44,7 +44,7 @@
                                -[ IMPORTANT ]-    
                if you had signed up to netsocadmin prior to the 
         2020/2021 academic year, you will need to reset your password:
-              https://admin.netsoc.co/account/password-reset
+              https://admin.netsoc.co/accounts/password-reset
 
              If you are new to Linux it is normal for the cursor to
                     not move when you type in your password

--- a/provision-docker-swarm-services.yml
+++ b/provision-docker-swarm-services.yml
@@ -348,3 +348,10 @@
     - ci
   tags:
     - ci
+
+- name: Wetty
+  hosts: docker_swarm_managers[0]
+  roles:
+    - wetty
+  tags:
+    - wetty

--- a/roles/wetty/tasks/main.yml
+++ b/roles/wetty/tasks/main.yml
@@ -1,0 +1,36 @@
+- become: yes
+  docker_stack:
+    name: wetty
+    compose:
+      - version: '3.8'
+        services:
+          server:
+            image: wettyoss/wetty@sha256:55efea8eac05a552acbb344449358f1fb10b7d7e06f192d20f4762bf1c4fc1d9
+            working_dir: /usr/src/app
+            networks:
+              traefik:
+            deploy:
+              mode: replicated
+              replicas: 1
+              restart_policy:
+                condition: any
+                delay: 5s
+                max_attempts: 5
+              labels:
+                - "traefik.enable=true"
+                - "traefik.http.routers.wetty.rule=Host(`portal.{{ co_site }}`)"
+                - "traefik.http.routers.wetty.entrypoints=web-secure"
+                - "traefik.http.routers.wetty.tls.certResolver=letsencrypt"
+                - "traefik.http.middlewares.wetty-path.redirectregex.regex=^https:\/\/portal.{{ co_site }}\/?$$"
+                - "traefik.http.middlewares.wetty-path.redirectregex.replacement=https:\/\/portal.{{ co_site }}\/wetty"
+                - "traefik.http.routers.wetty.middlewares=wetty-path"
+                - "traefik.http.services.wetty-service.loadbalancer.server.port=3000"
+                - "traefik.http.routers.wetty.service=wetty-service"
+                - "traefik.docker.network=traefik"
+            environment:
+              SSHHOST: "portal.vm.netsoc.co"
+              SSHPORT: 22
+        networks:
+          traefik:
+            name: traefik
+            external: true

--- a/setup-external-dns.yml
+++ b/setup-external-dns.yml
@@ -131,6 +131,7 @@
 
         # New - post proxmoxification
         - { type: A,     name: 80-443-swarm-ingress,  value: "84.39.234.53" }
+        - { type: CNAME, name: portal,                value: 80-443-swarm-ingress.netsoc.co }
         - { type: CNAME, name: wiki,                  value: 80-443-swarm-ingress.netsoc.co }
 
         # ;; CNAME Records


### PR DESCRIPTION
Add Wetty to access Portal from browser.

Running on swarm. Reverse Proxied by Traefik. Wetty configured to ssh to portal.vm.netsoc.co
Added portal.netsoc.co to DNS
Redirects from https://portal.netsoc.co & https://portal.netsoc.co/ to https://portal.netsoc.co/wetty