### PR TITLE
LXC Templates

### DIFF
--- a/lxc/ghostcms-ubuntu.yml
+++ b/lxc/ghostcms-ubuntu.yml
@@ -1,0 +1,133 @@
+- name: Requirements
+  hosts: container
+  tasks:
+    - name: Install nodejs
+      apt:
+        name: nodejs
+        state: present
+    # I couldn't get npm to install any other way /shrug
+    - name: Install npm
+      raw: apt-get install -y npm
+      args:
+        executable: /bin/bash
+    - name: Create ghost_manager group
+      group:
+        name: ghost_manager
+        system: yes
+    - name: Create ghost_manager user
+      user:
+        name: ghost_manager
+        home: /ghost
+        group: ghost_manager
+        shell: /bin/bash
+        password: "!"
+    - name: Make ghost_manager a sudoer
+      copy:
+        dest: /etc/sudoers.d/ghost_manager
+        content: ghost_manager  ALL=(ALL) NOPASSWD:ALL
+    - name: Global NPM
+      npm:
+        global: yes
+        production: yes
+        name: "{{ item }}"
+      loop:
+        - npm
+        - ghost-cli
+    - name: Permissions Helper
+      copy:
+        dest: /fix-permissions.sh
+        mode: 0770
+        content: |
+          #!/bin/bash
+          sudo find /ghost/ ! -path "./versions/*" -type f -exec chmod 00664 {} \;
+          sudo find /ghost/ -type d -exec chmod 00775 {} \;
+
+- name: Install Ghost
+  hosts: container
+  become: yes
+  become_user: ghost_manager
+  become_method: su
+  tasks:
+    - name: NPM install Ghost
+      npm:
+        name: ghost
+        production: yes
+        path: /ghost
+    - name: Get package.json contents
+      shell: cat /ghost/node_modules/ghost/package.json
+      register: package
+    - name: Get Ghost Version
+      set_fact:
+        ghost_version: "{{ (package.stdout | from_json).get('version') }}"
+    - name: Configure file structure
+      shell:
+        chdir: /ghost
+        executable: /bin/bash
+        cmd: |
+          mv /ghost/node_modules/ghost/content /ghost/content
+          mkdir -p /ghost/versions/{{ ghost_version }}
+          mkdir /ghost/.ghost
+          ln -sf /ghost/versions/{{ ghost_version }} current
+          mv /ghost/node_modules/ghost/* current/
+          mv package-lock.json current/
+          mv node_modules current/
+    - name: Ghost Config
+      copy:
+        dest: /ghost/config.production.json
+        content: |
+          {
+            "url": "https://PLACEHOLDER",
+            "server": {
+              "port": 6969,
+              "host": "0.0.0.0"
+            },
+            "database": {
+              "client": "sqlite3",
+              "connection": {
+                "filename": "/ghost/content/data/ghost.db",
+                "database": "ghost"
+              }
+            },
+            "mail": {
+              "transport": "Direct"
+            },
+            "logging": {
+              "path": "/ghost/content/logs",
+                "level": "info",
+                "rotation": {
+                "enabled": true,
+                "count": 15,
+                "period": "1d"
+              },
+              "transports": ["stdout", "file"]
+            },
+            "process": "systemd",
+            "paths": {
+              "contentPath": "/ghost/content"
+            }
+          }
+    - name: Instances Config
+      copy:
+        dest: /ghost/.ghost/config
+        content: |
+          {
+            "instances": {
+              "ghost": {
+                "cwd": "/ghost"
+              }
+            }
+          }
+    - name: Ghost CLI Config
+      copy:
+        dest: /ghost/.ghost-cli
+        content: |
+          {
+            "active-version": "{{ ghost_version }}",
+            "cli-version": "1",
+            "name": "ghost",
+            "running": "production"
+          }
+    - name: Finish Setup with Ghost-CLI
+      shell:
+        chdir: /ghost
+        cmd: ghost setup linux-user systemd migrate

--- a/lxc/nginx-ubuntu.yml
+++ b/lxc/nginx-ubuntu.yml
@@ -1,0 +1,11 @@
+- name: nginx
+  hosts: container
+  tasks:
+    - name: Install nginx
+      apt:
+        name: nginx
+        state: present
+    - name: Enable nginx
+      systemd:
+        name: nginx
+        enabled: yes

--- a/lxc/packer.json
+++ b/lxc/packer.json
@@ -6,7 +6,7 @@
             ],
             "type": "lxc",
             "name": "{{user `name`}}",
-            "config_file": "/etc/lxc/default.conf",
+            "config_file": "/lxc/lxc.conf",
             "container_name": "{{user `name`}}-{{user `dist`}}",
             "template_name": "download",
             "template_parameters": [
@@ -34,7 +34,7 @@
                 "lxc"
             ],
             "inventory_file_template": "container ansible_host={{user `name`}}-{{user `dist`}}",
-            "playbook_file": "./lxc/{{user `playbook`}}.yml"
+            "playbook_file": "/lxc/{{user `playbook`}}.yml"
         }
     ]
 }

--- a/lxc/packer.json
+++ b/lxc/packer.json
@@ -1,0 +1,40 @@
+{
+    "builders": [
+        {
+            "attach_options": [
+                "--clear-env"
+            ],
+            "type": "lxc",
+            "name": "{{user `name`}}",
+            "config_file": "/etc/lxc/default.conf",
+            "container_name": "{{user `name`}}-{{user `dist`}}",
+            "template_name": "download",
+            "template_parameters": [
+                "-d",
+                "{{user `dist`}}",
+                "-r",
+                "{{user `rel`}}",
+                "-a",
+                "amd64"
+            ],
+            "output_directory": "{{user `packer_output`}}/{{user `name`}}-{{user `dist`}}"
+        }
+    ],
+    "provisioners": [
+        {
+            "type": "shell",
+            "inline": [
+                "sleep 10"
+            ]
+        },
+        {
+            "type": "ansible",
+            "extra_arguments": [
+                "-c",
+                "lxc"
+            ],
+            "inventory_file_template": "container ansible_host={{user `name`}}-{{user `dist`}}",
+            "playbook_file": "./lxc/{{user `playbook`}}.yml"
+        }
+    ]
+}

--- a/lxc/packer.json
+++ b/lxc/packer.json
@@ -6,7 +6,7 @@
             ],
             "type": "lxc",
             "name": "{{user `name`}}",
-            "config_file": "/lxc/lxc.conf",
+            "config_file": "/etc/lxc/default.conf",
             "container_name": "{{user `name`}}-{{user `dist`}}",
             "template_name": "download",
             "template_parameters": [

--- a/provision-infra-container-templates.yml
+++ b/provision-infra-container-templates.yml
@@ -1,0 +1,129 @@
+- name: Setup
+  become: yes
+  hosts: localhost
+  tasks:
+    - name: Configure LXC to use a bridge
+      copy:
+        content: USE_LXC_BRIDGE="true"
+        dest: /etc/default/lxc-net
+        mode: 0774
+    - name: Configure general container settings
+      copy:
+        content: |
+          lxc.net.0.type = veth
+          lxc.net.0.link = lxcbr0
+          lxc.net.0.flags = up
+          lxc.net.0.hwaddr = 00:16:3e:xx:xx:xx
+        dest: /etc/lxc/default.conf
+        mode: 0774
+    - name: Start lxc-net service
+      service:
+        name: lxc-net
+        state: started
+    - name: Output Directories Vars
+      set_fact:
+        packer_output: /tmp/packer/output
+        template_output: /tmp/packer/templates
+    - name: Ensure Output Dirs
+      file:
+        path: "{{ item }}"
+        state: directory
+      loop:
+        - "{{ packer_output }}"
+        - "{{ template_output }}"
+
+# Command useful for local testing, replace UPPERCASE vars with appropriate values
+# Additional base templates can be found here http://uk.images.linuxcontainers.org
+# packer build -var "name=NAME" -var "dist=DIST" -var "rel=FOCAL" -var "playbook=PLAYBOOK" -var "packer_output=OUTPUT_DIR" ./lxc/packer.json
+- name: Templates
+  hosts: localhost
+  become: yes
+  tasks:
+    - name: Ghost CMS Ubuntu
+      command:
+        cmd: >
+          packer build
+          -var "name={{ name }}"
+          -var "dist={{ dist }}"
+          -var "rel={{ rel }}"
+          -var "playbook={{ playbook }}"
+          -var "packer_output={{ packer_output }}"
+          ./lxc/packer.json
+      vars:
+        name: ghostcms
+        dist: ubuntu
+        rel: focal
+        playbook: ghostcms-ubuntu
+      tags:
+        - ghostcms-ubuntu
+    - name: NGINX Ubuntu
+      command:
+        cmd: >
+          packer build
+          -var "name={{ name }}"
+          -var "dist={{ dist }}"
+          -var "rel={{ rel }}"
+          -var "playbook={{ playbook }}"
+          -var "packer_output={{ packer_output }}"
+          ./lxc/packer.json
+      vars:
+        name: nginx
+        dist: ubuntu
+        rel: focal
+        playbook: nginx-ubuntu
+      tags:
+        - nginx-ubuntu
+
+# Packer exports containers as rootfs.tar.gz with the following structure
+#   rootfs/
+#     - bin
+#     - boot
+#     - etc...
+# Proxmox expects bin,boot,etc... without parent rootfs dir
+# As such we must extract rootfs and then compress just its contents
+- name: Fix Archives
+  become: yes
+  hosts: localhost
+  tasks:
+    - name: Get all templates
+      find:
+        pattern: "rootfs.tar.gz"
+        path: "{{ packer_output }}"
+        recurse: yes
+      register: files
+    - name: Extract
+      shell:
+        cmd: "tar --preserve-permissions --numeric-owner -xzf {{ item.path }} -C {{ item.path | dirname }}"
+        warn: false
+      loop: "{{ files.files }}"
+    - name: Compress
+      shell:
+        cmd: "tar -czf {{ template_output }}/netsoc-{{ item.path.split('/')[-2] }}.tar.gz -C {{ item.path | dirname }}/rootfs ."
+        warn: false
+      loop: "{{ files.files }}"
+
+# synchronize might be a better module to use here
+- name: Copy Templates to Proxmox Nodes
+  become: yes
+  hosts: proxmox_nodes
+  tasks:
+    - name: Copy
+      copy:
+        src: "{{ template_output }}/"
+        dest: /var/lib/vz/template/cache/
+
+- name: Cleanup
+  become: yes
+  hosts: localhost
+  tasks:
+    - name: Stop lxc-net service
+      service:
+        name: lxc-net
+        state: stopped
+    - name: Tidy up outputs
+      file:
+        path: "{{ item }}"
+        state: absent
+      loop:
+        - "{{ packer_output }}"
+        - "{{ template_output }}"

--- a/provision-infra-container-templates.yml
+++ b/provision-infra-container-templates.yml
@@ -34,7 +34,7 @@
 
 # Command useful for local testing, replace UPPERCASE vars with appropriate values
 # Additional base templates can be found here http://uk.images.linuxcontainers.org
-# packer build -var "name=NAME" -var "dist=DIST" -var "rel=FOCAL" -var "playbook=PLAYBOOK" -var "packer_output=OUTPUT_DIR" ./lxc/packer.json
+# packer build -var "name=NAME" -var "dist=DIST" -var "rel=REL" -var "playbook=PLAYBOOK" -var "packer_output=OUTPUT_DIR" ./lxc/packer.json
 - name: Templates
   hosts: localhost
   become: yes

--- a/provision-infra-container-templates.yml
+++ b/provision-infra-container-templates.yml
@@ -1,12 +1,16 @@
 - name: Setup
   become: yes
-  hosts: localhost
+  hosts: lovelace
   tasks:
     - name: Configure LXC to use a bridge
       copy:
         content: USE_LXC_BRIDGE="true"
         dest: /etc/default/lxc-net
         mode: 0774
+    - name: Make /lxc dir
+      file:
+        state: directory
+        path: /lxc
     - name: Configure general container settings
       copy:
         content: |
@@ -16,10 +20,6 @@
           lxc.net.0.hwaddr = 00:16:3e:xx:xx:xx
         dest: /etc/lxc/default.conf
         mode: 0774
-    - name: Start lxc-net service
-      service:
-        name: lxc-net
-        state: started
     - name: Output Directories Vars
       set_fact:
         packer_output: /tmp/packer/output
@@ -31,12 +31,33 @@
       loop:
         - "{{ packer_output }}"
         - "{{ template_output }}"
+    - name: lxc-dev package
+      apt:
+        name: lxc-pve-dev
+    - name: python3 lxc bindings
+      pip:
+        name: git+https://github.com/lxc/python3-lxc
+  roles:
+    - packer
+  tags:
+    - always
+
+- name: Delegate to Lovelace
+  become: yes
+  hosts: lovelace
+  tasks:
+  - name: Copy provisioning files
+    copy:
+      src: ./lxc/
+      dest: /lxc/
+  tags:
+    - always
 
 # Command useful for local testing, replace UPPERCASE vars with appropriate values
 # Additional base templates can be found here http://uk.images.linuxcontainers.org
-# packer build -var "name=NAME" -var "dist=DIST" -var "rel=REL" -var "playbook=PLAYBOOK" -var "packer_output=OUTPUT_DIR" ./lxc/packer.json
+# packer build -var "name=NAME" -var "dist=DIST" -var "rel=REL" -var "playbook=PLAYBOOK" -var "packer_output=OUTPUT_DIR" /lxc/packer.json
 - name: Templates
-  hosts: localhost
+  hosts: lovelace
   become: yes
   tasks:
     - name: Ghost CMS Ubuntu
@@ -48,7 +69,7 @@
           -var "rel={{ rel }}"
           -var "playbook={{ playbook }}"
           -var "packer_output={{ packer_output }}"
-          ./lxc/packer.json
+          /lxc/packer.json
       vars:
         name: ghostcms
         dist: ubuntu
@@ -56,7 +77,7 @@
         playbook: ghostcms-ubuntu
       tags:
         - ghostcms-ubuntu
-    - name: NGINX Ubuntu
+    - name: nginx Ubuntu
       command:
         cmd: >
           packer build
@@ -65,7 +86,7 @@
           -var "rel={{ rel }}"
           -var "playbook={{ playbook }}"
           -var "packer_output={{ packer_output }}"
-          ./lxc/packer.json
+          /lxc/packer.json
       vars:
         name: nginx
         dist: ubuntu
@@ -83,7 +104,7 @@
 # As such we must extract rootfs and then compress just its contents
 - name: Fix Archives
   become: yes
-  hosts: localhost
+  hosts: lovelace
   tasks:
     - name: Get all templates
       find:
@@ -101,20 +122,25 @@
         cmd: "tar -czf {{ template_output }}/netsoc-{{ item.path.split('/')[-2] }}.tar.gz -C {{ item.path | dirname }}/rootfs ."
         warn: false
       loop: "{{ files.files }}"
+  tags:
+   - always
 
-# synchronize might be a better module to use here
-- name: Copy Templates to Proxmox Nodes
+- name: Copy Templates to Proxmox Hosts
   become: yes
-  hosts: proxmox_nodes
+  hosts: proxmox_hosts
   tasks:
-    - name: Copy
-      copy:
-        src: "{{ template_output }}/"
-        dest: /var/lib/vz/template/cache/
+    - name: Copy templates
+      synchronize:
+        src: "{{ hostvars['lovelace']['template_output'] }}/"
+        dest: "/var/lib/vz/template/cache/"
+      delegate_to: lovelace
+      delegate_facts: true
+  tags:
+    - always
 
 - name: Cleanup
   become: yes
-  hosts: localhost
+  hosts: lovelace
   tasks:
     - name: Stop lxc-net service
       service:
@@ -127,3 +153,5 @@
       loop:
         - "{{ packer_output }}"
         - "{{ template_output }}"
+  tags:
+   - always

--- a/provision-infra-container-templates.yml
+++ b/provision-infra-container-templates.yml
@@ -7,6 +7,10 @@
         content: USE_LXC_BRIDGE="true"
         dest: /etc/default/lxc-net
         mode: 0774
+    - name: Start lxc-net service
+      service:
+        name: lxc-net
+        state: started
     - name: Make /lxc dir
       file:
         state: directory

--- a/roles/packer/tasks/main.yml
+++ b/roles/packer/tasks/main.yml
@@ -4,9 +4,9 @@
     name:  unzip
     state: present
 
-- name: Ensure Packer 1.5.5
+- name: Ensure Packer 1.6.5
   unarchive:
-    src: https://releases.hashicorp.com/packer/1.5.6/packer_1.5.6_linux_amd64.zip
+    src: https://releases.hashicorp.com/packer/1.6.5/packer_1.6.5_linux_amd64.zip
     dest: /usr/local/bin
     mode: +x
     remote_src: yes


### PR DESCRIPTION
With this we can provision our own custom LXC templates for use with Proxmox.

More templates are needed but this includes
- Ghost CMS
- Basic nginx (more of an example than practical)

Some templates, like Ghost CMS, will require runtime config which will need to be documented somewhere